### PR TITLE
add word wrap to text

### DIFF
--- a/client/src/index.css
+++ b/client/src/index.css
@@ -481,6 +481,7 @@ a.head_text:hover {
   font-weight: 500;
   line-height: 1.6;
   overflow-wrap: break-word;
+  word-break: break-all;
 }
 @media (min-width: 400px) {
   .card_content {


### PR DESCRIPTION
![Screenshot 2021-06-16 162856](https://user-images.githubusercontent.com/66725692/122203602-05b93a80-cec0-11eb-86a7-e911980b48a7.png)

so the text didn't wrap on longer text , so added the css property to fix it

![Screenshot 2021-06-16 163112](https://user-images.githubusercontent.com/66725692/122203864-47e27c00-cec0-11eb-8862-c4e00da791fa.png)
